### PR TITLE
Fix crash when the game is flushing a mouse buffer.

### DIFF
--- a/Kanan/DInputHook.cpp
+++ b/Kanan/DInputHook.cpp
@@ -96,9 +96,16 @@ namespace kanan {
             device->SetCooperativeLevel(dinput->m_wnd, DISCL_FOREGROUND | DISCL_NONEXCLUSIVE);
             device->Acquire();
 
-            dinput->m_deviceObjectData.resize(*numElements);
+            if (*numElements == -1 || data == nullptr) // detect buffer flush
+            {
+                return originalGetDeviceData(device, size, data, numElements, flags);
+            }
+            else
+            {
+                dinput->m_deviceObjectData.resize(*numElements);
 
-            originalGetDeviceData(device, size, dinput->m_deviceObjectData.data(), numElements, flags);
+                originalGetDeviceData(device, size, dinput->m_deviceObjectData.data(), numElements, flags);
+            }
 
             *numElements = 0;
 


### PR DESCRIPTION
> Your application can flush the buffer and retrieve the number of flushed items by specifying NULL
> for the rgdod parameter and a pointer to a variable containing INFINITE for the pdwInOut parameter. 
> The following code example illustrates how this can be done.
```
dwItems = INFINITE; 
hres = idirectinputdevice9_GetDeviceData( 
            pdid, 
            sizeof(DIDEVICEOBJECTDATA), 
            NULL, 
            &dwItems, 
            0); 
if (SUCCEEDED(hres)) { 
    // Buffer successfully flushed. 
    // dwItems = Number of elements flushed. 
    if (hres == DI_BUFFEROVERFLOW) { 
        // Buffer had overflowed. 
    } 
}
```
https://msdn.microsoft.com/en-us/library/windows/desktop/microsoft.directx_sdk.idirectinputdevice8.idirectinputdevice8.getdevicedata(v=vs.85).aspx