### PR TITLE
fix crash when other jsons in mabi folder

### DIFF
--- a/Kanan/Kanan.cpp
+++ b/Kanan/Kanan.cpp
@@ -25,7 +25,7 @@ namespace kanan {
         m_dinputHook{ nullptr },
         m_wmHook{ nullptr },
         m_game{ nullptr },
-        m_mods{ m_path },
+        m_mods{ m_path + "/kanan"},
         m_isUIOpen{ true },
         m_isLogOpen{ false },
         m_isAboutOpen{ false },

--- a/Kanan/Kanan.vcxproj
+++ b/Kanan/Kanan.vcxproj
@@ -64,11 +64,14 @@
       <AdditionalDependencies>ws2_32.lib;MinHook.lib;ImGui.lib;FreeType.lib;Core.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
-      <Command>copy "$(ProjectDir)Patches.json" "$(OutDir)Patches.json"</Command>
+      <Command>copy "$(ProjectDir)Patches.json" "$(OutDir)kanan\Patches.json"</Command>
     </PostBuildEvent>
     <PostBuildEvent>
       <Message>Copying Patches.json to output directory</Message>
     </PostBuildEvent>
+    <PreBuildEvent>
+      <Command>if not exist "$(OutDir)kanan" mkdir "$(OutDir)kanan"</Command>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>


### PR DESCRIPTION
if we have other unrelated json folders in the mabi directory kanan will cause mabi to crash

moves patches into a kanan folder