### PR TITLE
[WIP] Cursor Unhide for Chain skills, need help

### DIFF
--- a/Kanan/CursorUnhide.cpp
+++ b/Kanan/CursorUnhide.cpp
@@ -1,0 +1,60 @@
+#include <imgui.h>
+
+#include <Scan.hpp>
+
+#include "Log.hpp"
+#include "CursorUnhide.hpp"
+
+using namespace std;
+
+namespace kanan {
+	CursorUnhide::CursorUnhide()
+		: m_isEnabled{ false },
+		m_patch{}
+	{
+		auto address = scan("client.exe", "68 B5 00 00 00 50 FF D7 89 86 70 01 00 00 8B 0D");
+		if (address) {
+			log("Got CursorUnhide %p", *address);
+			m_patch.address = *address + 1; // offset
+
+		} else {
+			log("Failed to find CursorUnhide address");
+		}
+	}
+
+	void CursorUnhide::onUI() {
+		if (ImGui::CollapsingHeader("Chain Cursor Unhide")) {
+			ImGui::TextWrapped(
+				"Prevents the game from hiding the 2D cursor when displaying the 3D cursor for chain skills."
+				"NOTE: You must restart the game after enabling or disabling this mod for it take effect."
+			);
+			ImGui::Spacing();
+
+			if (ImGui::Checkbox("Chain Cursor Unhide", &m_isEnabled)) {
+				apply();
+			}
+		}
+	}
+
+	void CursorUnhide::onConfigLoad(const Config& cfg) {
+		m_isEnabled = cfg.get<bool>("CursorUnhide.Enabled").value_or(false);
+
+		if (m_isEnabled) {
+			apply();
+		}
+	}
+
+	void CursorUnhide::onConfigSave(Config& cfg) {
+		cfg.set<bool>("CursorUnhide.Enabled", m_isEnabled);
+	}
+
+	void CursorUnhide::apply() {
+		if (!m_isEnabled || m_patch.address == 0) {
+			return;
+		}
+		m_patch.bytes = { 65 };
+
+		log("Applying Cursor Unhide...");
+		patch(m_patch);
+	}
+}

--- a/Kanan/CursorUnhide.cpp
+++ b/Kanan/CursorUnhide.cpp
@@ -8,53 +8,54 @@
 using namespace std;
 
 namespace kanan {
-	CursorUnhide::CursorUnhide()
-		: m_isEnabled{ false },
-		m_patch{}
-	{
-		auto address = scan("client.exe", "68 B5 00 00 00 50 FF D7 89 86 70 01 00 00 8B 0D");
-		if (address) {
-			log("Got CursorUnhide %p", *address);
-			m_patch.address = *address + 1; // offset
+    CursorUnhide::CursorUnhide()
+        : m_isEnabled{ false },
+        m_patch{}
+    {
+        auto address = scan("client.exe", "68 B5 00 00 00 50 FF D7 89 86 70 01 00 00 8B 0D");
+        if (address) {
+            log("Got CursorUnhide %p", *address);
+            m_patch.address = *address + 1; // offset
 
-		} else {
-			log("Failed to find CursorUnhide address");
-		}
-	}
+        }
+        else {
+            log("Failed to find CursorUnhide address");
+        }
+    }
 
-	void CursorUnhide::onUI() {
-		if (ImGui::CollapsingHeader("Chain Cursor Unhide")) {
-			ImGui::TextWrapped(
-				"Prevents the game from hiding the 2D cursor when displaying the 3D cursor for chain skills."
-				"NOTE: You must restart the game after enabling or disabling this mod for it take effect."
-			);
-			ImGui::Spacing();
+    void CursorUnhide::onUI() {
+        if (ImGui::CollapsingHeader("Chain Cursor Unhide")) {
+            ImGui::TextWrapped(
+                "Prevents the game from hiding the 2D cursor when displaying the 3D cursor for chain skills."
+                "NOTE: You must restart the game after enabling or disabling this mod for it take effect."
+            );
+            ImGui::Spacing();
 
-			if (ImGui::Checkbox("Chain Cursor Unhide", &m_isEnabled)) {
-				apply();
-			}
-		}
-	}
+            if (ImGui::Checkbox("Chain Cursor Unhide", &m_isEnabled)) {
+                apply();
+            }
+        }
+    }
 
-	void CursorUnhide::onConfigLoad(const Config& cfg) {
-		m_isEnabled = cfg.get<bool>("CursorUnhide.Enabled").value_or(false);
+    void CursorUnhide::onConfigLoad(const Config& cfg) {
+        m_isEnabled = cfg.get<bool>("CursorUnhide.Enabled").value_or(false);
 
-		if (m_isEnabled) {
-			apply();
-		}
-	}
+        if (m_isEnabled) {
+            apply();
+        }
+    }
 
-	void CursorUnhide::onConfigSave(Config& cfg) {
-		cfg.set<bool>("CursorUnhide.Enabled", m_isEnabled);
-	}
+    void CursorUnhide::onConfigSave(Config& cfg) {
+        cfg.set<bool>("CursorUnhide.Enabled", m_isEnabled);
+    }
 
-	void CursorUnhide::apply() {
-		if (!m_isEnabled || m_patch.address == 0) {
-			return;
-		}
-		m_patch.bytes = { 65 };
+    void CursorUnhide::apply() {
+        if (!m_isEnabled || m_patch.address == 0) {
+            return;
+        }
+        m_patch.bytes = { 65 };
 
-		log("Applying Cursor Unhide...");
-		patch(m_patch);
-	}
+        log("Applying Cursor Unhide...");
+        patch(m_patch);
+    }
 }

--- a/Kanan/CursorUnhide.hpp
+++ b/Kanan/CursorUnhide.hpp
@@ -6,19 +6,19 @@
 #include "Patch.hpp"
 
 namespace kanan {
-	class CursorUnhide : public Mod {
-	public:
-		CursorUnhide();
+    class CursorUnhide : public Mod {
+    public:
+        CursorUnhide();
 
-		void onUI() override;
+        void onUI() override;
 
-		void onConfigLoad(const Config& cfg) override;
-		void onConfigSave(Config& cfg) override;
+        void onConfigLoad(const Config& cfg) override;
+        void onConfigSave(Config& cfg) override;
 
-	private:
-		bool m_isEnabled;
-		Patch m_patch;
+    private:
+        bool m_isEnabled;
+        Patch m_patch;
 
-		void apply();
-	};
+        void apply();
+    };
 }

--- a/Kanan/CursorUnhide.hpp
+++ b/Kanan/CursorUnhide.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <cstdint>
+
+#include "Mod.hpp"
+#include "Patch.hpp"
+
+namespace kanan {
+	class CursorUnhide : public Mod {
+	public:
+		CursorUnhide();
+
+		void onUI() override;
+
+		void onConfigLoad(const Config& cfg) override;
+		void onConfigSave(Config& cfg) override;
+
+	private:
+		bool m_isEnabled;
+		Patch m_patch;
+
+		void apply();
+	};
+}

--- a/Kanan/Kanan.vcxproj
+++ b/Kanan/Kanan.vcxproj
@@ -96,6 +96,7 @@
     <ClCompile Include="AutoSetMTU.cpp" />
     <ClCompile Include="BorderlessWindow.cpp" />
     <ClCompile Include="ColorAltText.cpp" />
+    <ClCompile Include="CursorUnhide.cpp" />
     <ClCompile Include="D3D9Hook.cpp" />
     <ClCompile Include="DInputHook.cpp" />
     <ClCompile Include="DisableNagle.cpp" />
@@ -123,6 +124,7 @@
     <ClInclude Include="AutoSetMTU.hpp" />
     <ClInclude Include="BorderlessWindow.hpp" />
     <ClInclude Include="ColorAltText.hpp" />
+    <ClInclude Include="CursorUnhide.hpp" />
     <ClInclude Include="D3D9Hook.hpp" />
     <ClInclude Include="DInputHook.hpp" />
     <ClInclude Include="DisableNagle.hpp" />

--- a/Kanan/Kanan.vcxproj.filters
+++ b/Kanan/Kanan.vcxproj.filters
@@ -108,6 +108,9 @@
     <ClCompile Include="StatusUI.cpp">
       <Filter>Source Files\Mods</Filter>
     </ClCompile>
+    <ClCompile Include="CursorUnhide.cpp">
+      <Filter>Source Files\Mods</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="D3D9Hook.hpp">
@@ -189,6 +192,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="StatusUI.hpp">
+      <Filter>Header Files\Mods</Filter>
+    </ClInclude>
+    <ClInclude Include="CursorUnhide.hpp">
       <Filter>Header Files\Mods</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Kanan/Mods.cpp
+++ b/Kanan/Mods.cpp
@@ -46,7 +46,7 @@ namespace kanan {
         log("[Mods] Loading time critical mods...");
 
         addMod(make_unique<UseDataFolder>());
-		addMod(make_unique<CursorUnhide>());
+        addMod(make_unique<CursorUnhide>());
 
         // Time critical mods need to have their settings loaded from the config
         // right away.

--- a/Kanan/Mods.cpp
+++ b/Kanan/Mods.cpp
@@ -21,6 +21,7 @@
 #include "TTFFontSize.hpp"
 #include "SecondaryPassword.hpp"
 #include "StatusUI.hpp"
+#include "CursorUnhide.hpp"
 
 #include "Log.hpp"
 
@@ -45,6 +46,7 @@ namespace kanan {
         log("[Mods] Loading time critical mods...");
 
         addMod(make_unique<UseDataFolder>());
+		addMod(make_unique<CursorUnhide>());
 
         // Time critical mods need to have their settings loaded from the config
         // right away.


### PR DESCRIPTION
#48 @Iuke121 was able to find the address/edit to skip hiding the 2D cursor for chain skills, using the (currently working) version from the koorimio mod, however it still doesn't work. I tried as a simple patch in Patches.json, and then tried it as an early "time critical" mod alongside the data folder change, just in case the cursor is some kind of engine thing that needs to be jmped early for whatever reason. Still no luck.

Intended result, using koorimio.dll: 
![image](https://user-images.githubusercontent.com/5201917/45581312-996e0000-b869-11e8-9852-4648b05dbd15.png)

Current result, glitchy at best and only while moving, under certain crazy circumstances, rapidly blinking on/off: https://webmshare.com/play/y691B