### PR TITLE
Fix No Flashy Crashing until I can reproduce

### DIFF
--- a/Kanan/EquipmentOverride.cpp
+++ b/Kanan/EquipmentOverride.cpp
@@ -253,9 +253,6 @@ namespace kanan {
             color[0] &= 0x00FFFFFF;
             color[1] &= 0x00FFFFFF;
             color[2] &= 0x00FFFFFF;
-            color[4] &= 0x00FFFFFF;
-            color[5] &= 0x00FFFFFF;
-            color[6] &= 0x00FFFFFF;
         }
 
         // Filter out other characters.


### PR DESCRIPTION
The additional dye slots will crash the client when you try to log in if you have No Flashy enabled.
Equipment Override dye spots however works correctly with all 6 dye spots.
Note: The issue of colours not saving correctly and some turning more yellow is still existing, mentioned in #102