### PR TITLE
Fix crash running Loader after start

### DIFF
--- a/Kanan/D3D9Hook.cpp
+++ b/Kanan/D3D9Hook.cpp
@@ -19,7 +19,6 @@ namespace kanan {
         if (g_d3d9Hook == nullptr) {
             if (hook()) {
                 log("D3D9Hook hooked successfully.");
-                g_d3d9Hook = this;
             }
             else {
                 log("D3D9Hook failed to hook.");
@@ -37,6 +36,10 @@ namespace kanan {
 
     bool D3D9Hook::hook() {
         log("Entering D3D9Hook::hook().");
+
+        // Set hook object preemptively -- otherwise, the hook is written and is likely
+        // to execute and crash before we verify success.
+        g_d3d9Hook = this;
 
         // All we do here is create a IDirect3DDevice9 so that we can get the address
         // of the methods we want to hook from its vtable.
@@ -103,7 +106,14 @@ namespace kanan {
         m_presentHook = make_unique<FunctionHook>(present, (uintptr_t)&D3D9Hook::present);
         m_resetHook = make_unique<FunctionHook>(reset, (uintptr_t)&D3D9Hook::reset);
 
-        return m_presentHook->isValid() && m_resetHook->isValid();
+        if (m_presentHook->isValid() && m_resetHook->isValid()) {
+            return true;
+        }
+        else {
+            // If a problem occurred, reset the hook.
+            g_d3d9Hook = nullptr;
+            return false;
+        }
     }
 
     HRESULT D3D9Hook::present(IDirect3DDevice9* device, CONST RECT* src, CONST RECT* dest, HWND wnd, CONST RGNDATA* dirtyRgn) {

--- a/Kanan/D3D9Hook.cpp
+++ b/Kanan/D3D9Hook.cpp
@@ -111,6 +111,8 @@ namespace kanan {
         }
         else {
             // If a problem occurred, reset the hook.
+            m_presentHook.reset();
+            m_resetHook.reset();
             g_d3d9Hook = nullptr;
             return false;
         }


### PR DESCRIPTION
I rarely remember to run Loader before running mabi, so I'm constantly crashing and re-opening mabi when I want to use kanan. It seems like that primary crash is very simple to resolve (race condition with hook pointer) which is nice QOL for me personally, but since this is suddenly violating an expected precondition of all mods, it probably needs more testing/discussion.

In any case, if others want this functionality, this change lets me run kanan after loading into the game with most mods enabled. There are some expected minor bugs (CP not showing on characters that existed prior to running Kanan) but I haven't crashed at all yet, so that's a good sign?

(Technical explanation: `g_d3d9Hook` is set **after** `hook()` returns, by which point it has already set the code hook. So if D3D is running, it's a race condition where D3D loop will fire the hook and fault due to null pointer in the tiny window before it's finished being set)