### PR TITLE
Fix 'Faster Networking' mod

### DIFF
--- a/Kanan/Patches.json
+++ b/Kanan/Patches.json
@@ -769,10 +769,6 @@
         "category": "Speedup",
         "patches": [
             {
-                "pattern": "74 ? 8B 45 F0 51",
-                "patch": "EB"
-            },
-            {
                 "pattern": "75 ? B0 ? 5E C3 90",
                 "patch": "90 90"
             },


### PR DESCRIPTION
The site of the first patch now calls the function where the second
patch is whereas it didn't before, so it seems to have become
redundant. It also causes you to get kicked when you go to login screen
(probably whenever your client creates a new connection) and didn't
have any impact on packet throughput testing I did.