### PR TITLE
Update launcher logip and logport

### DIFF
--- a/Launcher/LauncherApp.cpp
+++ b/Launcher/LauncherApp.cpp
@@ -472,8 +472,8 @@ void LauncherApp::mainUI() {
                             "locale:USA " <<
                             "env:Regular " <<
                             "setting:file://data/features.xml " <<
-                            "logip:35.162.171.43 " <<
-                            "logport:11000 " <<
+                            "logip:54.214.43.237 " <<
+                            "logport:11002 " <<
                             "chatip:54.214.176.167 " <<
                             "chatport:8002 " <<
                             "/P:" << passport << " " <<


### PR DESCRIPTION
This also fixes a bug is a known and ongoing bug reported by Nexon since the merge. [See bug](https://i.imgur.com/xd610Q1.png).
Upon logging out of game, the player has a chance of disconnecting from character selection screen. 

Found 3 IPs:

52.88.59.74:11000
54.214.43.237:11002
100.21.32.129:11001

Through trial and error, 54.214.43.237 appears to be the most stable IP out of the other two IPs.
