### PR TITLE
Add don't close title window patch to patches.json in quality of life section

### DIFF
--- a/Kanan/Patches.json
+++ b/Kanan/Patches.json
@@ -1252,5 +1252,16 @@
         "patch": "01"
       }
     ]
+  },
+  {
+    "name": "Don't Close Title Window",
+    "desc": "Disables the automatic closing of the title window when switching titles.",
+    "category": "Quality of Life",
+    "patches": [
+      {
+        "pattern": "FF 50 ? E9 ? ? ? ? 8B 86 ? ? ? ? 3B 48 ? 75 ? 8B CE",
+        "patch": "90 90 90"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Add don't close title window patch to patches.json in quality of life section. Prevents closing the title window from closing automatically when switching titles. 