### PR TITLE
Fix: Remove Item Drop animation

### DIFF
--- a/Kanan/Patches.json
+++ b/Kanan/Patches.json
@@ -1130,8 +1130,8 @@
         "category": "Speedup",
         "patches": [
             {
-                "pattern": "0F 84 17 02 00 00 39 9E",
-                "patch": "90 E9"
+                "pattern": "0F 84 ? ? ? ? 83 BE 04 01 00 00",
+                "patch": "0F 85"
             }
         ]
     },


### PR DESCRIPTION
Old patch was looking for jump to exact address on its scan. that address changed.