### PR TITLE
fix cooking mod for x64, expose call api for FunctionHook

### DIFF
--- a/Core/FunctionHook.hpp
+++ b/Core/FunctionHook.hpp
@@ -24,6 +24,10 @@ namespace kanan {
             return m_hook != nullptr;
         }
 
+        template <typename RetT = void, typename... Args> auto callOriginal(Args... args) {
+            return m_hook->call<RetT>(args...);
+        }
+
         FunctionHook& operator=(const FunctionHook& other) = delete;
         FunctionHook& operator=(FunctionHook&& other) = delete;
 

--- a/Kanan/CookingMod.hpp
+++ b/Kanan/CookingMod.hpp
@@ -1,15 +1,12 @@
 #pragma once
-#include <vector>
-#include <windows.h>
-#include <TlHelp32.h>
+#include "FunctionHook.hpp"
 #include "Mod.hpp"
 namespace kanan {
 	class CookingMod :
 		public Mod
 	{
 	public:
-		CookingMod();
-		void applycook(bool m_cooking_is_enabled);
+		CookingMod();		
 
 		void onUI() override;
 
@@ -24,6 +21,8 @@ namespace kanan {
 		//void onKeyDown(DWORD key);
 
 	private:
+        std::unique_ptr<FunctionHook> m_hook;
 		bool m_is_enabled{};
+        static void __fastcall HookForCooking(int* _this, int ingredientIdx, int amount);
 	};
 }

--- a/Kanan/Mods.cpp
+++ b/Kanan/Mods.cpp
@@ -123,7 +123,7 @@ namespace kanan {
         addMod(make_unique<BorderlessWindow>());
         addMod(make_unique<EnableMultiClient>());
         addMod(make_unique<EntityViewer>());
-        // addMod(make_unique<CookingMod>());
+        addMod(make_unique<CookingMod>());
         addMod(make_unique<EquipmentOverride>());
         addMod(make_unique<FieldOfView>());
         addMod(make_unique<FreezeTimeOfDay>());


### PR DESCRIPTION
Fix cooking mod for x64 with FunctionHook method instead of asm. For the convenience of implementation, I have exposed CallOriginal in FunctionHook. Also cleanup unnecessary code in CookingMod